### PR TITLE
Set run-time ngsolve dependency correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,16 @@ version = "0.0.1"
 description="NGSolve add on for the dual cell method"
 readme = "README.md"
 requires-python = ">=3.8"
+dynamic = ["dependencies"]
 classifiers = [
   "License :: OSI Approved :: MIT License",
 ]
 
 [build-system]
-requires = ["scikit-build-core>=0.3.3", "pybind11", "pybind11_stubgen", "cmake", "netgen-mesher", "ngsolve"]
+requires = ["scikit-build-core>=0.9.0", "pybind11_stubgen", "cmake", "toml", "ngsolve>=6.2.2403.post91.dev0"] # TODO: update this to ngsolve>=6.2.2404, when it is released
 build-backend = "scikit_build_core.build"
 
+[tool.scikit-build]
+experimental = true
+# This adds ngsolve (with exact build-time version) to the dependencies
+metadata.dependencies.provider="ngsolve._scikit_build_core_dependencies"


### PR DESCRIPTION
This should ensure that the NGSolve version at build-time and run-time are matching.
Needs a recent ngsolve dev version (update the dependency, once the next NGSolve version is released as stated in the todo).

Depending on how you installed ngsolve, the install procedure of the plugin might have side effects. See [here](https://github.com/NGSolve/ngsolve-addon-template/tree/advanced?tab=readme-ov-file#install-methods-compatiblity-useful-for-developers) for more information about that.